### PR TITLE
NGX-230: fix bug in redis + mariadb process checks

### DIFF
--- a/templates/services/mariadb
+++ b/templates/services/mariadb
@@ -1,7 +1,7 @@
 # {{ template_destpath }}
 # {{ ansible_managed }}
 
-check process mariadb with pidfile /var/run/{{ mysql_daemon }}//{{ mysql_daemon }}.pid
+check process mariadb matching "mariadbd"
   group mysql
   start program = "/bin/systemctl start {{ mysql_daemon }}"
   stop program = "/bin/systemctl stop {{ mysql_daemon }}"

--- a/templates/services/redis
+++ b/templates/services/redis
@@ -1,7 +1,7 @@
 # {{ template_destpath }}
 # {{ ansible_managed }}
 
-check process redis with pidfile /var/run/{{ redis_daemon }}/{{ redis_daemon }}.pid
+check process redis matching "redis"
   group redis
   start program = "/bin/systemctl start {{ redis_daemon }}"
   stop program = "/bin/systemctl stop {{ redis_daemon }}"


### PR DESCRIPTION
- Use process name to check status instead of pid file for redis and mariadb