### PR TITLE
NGX-812: Wait 3 cycles before restart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # requirements.txt
 
 ansible-lint
-ansible>=6,<7
+ansible
 molecule-plugins[docker]
-molecule>=5,<6
+molecule
 pre-commit

--- a/templates/services/mariadb
+++ b/templates/services/mariadb
@@ -5,4 +5,4 @@ check process mariadb matching "mariadbd"
   group mysql
   start program = "/bin/systemctl start {{ mysql_daemon }}"
   stop program = "/bin/systemctl stop {{ mysql_daemon }}"
-  if failed port 3306 protocol mysql timeout 15 seconds then restart
+  if failed port 3306 protocol mysql timeout 15 seconds for 3 cycles then restart


### PR DESCRIPTION
When MySQL is restarting it can coincide with a monit check.  If monit fails to connect it will try and restart the srevice (stop/start).  This can cause the initial restart to fail with error, "Job for mariadb.service canceled." and result in a playbook failure for the restart mysql handler.  This configure monit to wait for 3 failed cycles before attempting a restart on the mariadb service.